### PR TITLE
Add inkscape for MagickWand SVG handling.

### DIFF
--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -28,6 +28,7 @@ RUN apt-get update \
         python3-uno python3-lxml python3-icu curl imagemagick libmagickwand-dev \
         python-setuptools git libavformat-dev libavcodec-dev libavutil-dev \
         libswscale-dev libavfilter-dev libswresample-dev libavdevice-dev inotify-tools \
+        inkscape \
     && apt-get -y autoremove \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*


### PR DESCRIPTION
Added inkscape package to base image and verified `inkscape` CLI command is present.