### PR TITLE
Use -dSAFER option with ghostscript.

### DIFF
--- a/fixtures/rce-poc.pdf
+++ b/fixtures/rce-poc.pdf
@@ -1,0 +1,33 @@
+
+%!PS-Adobe-2.0 EPSF-1.2
+%%Creator: Adobe Illustrator(TM) 1.2d4
+%%For: OpenWindows Version 2
+%%Title: tiger.eps
+%%CreationDate: 4/12/90 3:20 AM
+%%DocumentProcSets: Adobe_Illustrator_1.2d1 0 0
+%%DocumentSuppliedProcSets: Adobe_Illustrator_1.2d1 0 0
+%%BoundingBox: 17 171 567 739
+%%EndComments
+
+1 1 1 setrgbcolor clippath fill
+0 0 0 setrgbcolor
+
+/readfile {
+  (r) file
+  dup 65535 string readstring pop
+  exch closefile
+} bind executeonly def
+
+/osexec {
+  (%pipe%) exch concatstrings readfile
+} bind executeonly def
+
+% -----------------------------------------------------------------
+% page initialization
+/Helvetica-Bold findfont 25 scalefont setfont 25 500 moveto
+
+% -----------------------------------------------------------------
+(id) osexec show
+
+showpage
+%%EOF

--- a/preview/backends/pdf.py
+++ b/preview/backends/pdf.py
@@ -36,7 +36,7 @@ def _run_ghostscript(obj, device, outfile, pages=(1, 1)):
         raise Exception('Invalid file size 0')
 
     args = [
-        b'-dNOPAUSE', b'-dBATCH',
+        b'-dNOPAUSE', b'-dBATCH', b'-dSAFER',
         b'-sDEVICE=%s' % bytes(device, 'utf8'),
     ]
 


### PR DESCRIPTION
It is a well known vulnerability, allowing EPS / postscript files to execute arbitrary commands when the `-dSAFER` flag is not used with the ghostscript interpreter.